### PR TITLE
Linked decision cards

### DIFF
--- a/ui.html
+++ b/ui.html
@@ -1013,22 +1013,18 @@
         
         container.appendChild(card);
         
-        // Make the entire card clickable to view details
+        // Make the entire card clickable to view details and navigate to linked element
         card.addEventListener('click', (e) => {
-          // Check if the click was on a node link (which has its own handler)
-          if (e.target.closest('.figma-node-link .tag')) {
-            // If clicking on the node link, navigate to the element
-            const figmaNodeLink = e.target.closest('.figma-node-link .tag');
-            const nodeId = figmaNodeLink.dataset.nodeId;
-            navigateToNode(nodeId, decision.pageName);
-            // We still want to show the details after navigating to the node
-            setTimeout(() => {
-              viewDecisionDetails(decision.id);
-            }, 100);
-            return;
-          }
-          // Otherwise just open the decision details
+          // First, open the details panel
           viewDecisionDetails(decision.id);
+          
+          // If there's a linked element, also navigate to it
+          if (decision.nodeId) {
+            // If we're clicking directly on the node link tag, don't double-navigate
+            if (!e.target.closest('.figma-node-link .tag')) {
+              navigateToNode(decision.nodeId, decision.pageName);
+            }
+          }
         });
       });
     }


### PR DESCRIPTION
1. Added CSS to improve the clickable affordance of decision cards
2. Enhanced the card click functionality to handle clicks on the Figma element
3. Added behavior to navigate to the Figma element when clicking on a linked element
4. Updated the node link behavior in the details panel
5. Added an event listener for the Navigate to Element button
6. Added logic to show/hide the navigate button based on whether there's a linked node

Modified the card click event handler to:

1. Open the details panel for the decision
- If there's a linked Figma element, navigate to it
- Prevent double-navigation when clicking directly on the node link

2. The linked element behavior now works as follows:
- Clicking anywhere on a card with a linked element will navigate to that element and open details
- This provides a seamless experience similar to Figma comments